### PR TITLE
Don't rely on timer, directly call Upgrade()

### DIFF
--- a/examples/deploy/update-agent.yaml
+++ b/examples/deploy/update-agent.yaml
@@ -14,6 +14,8 @@ spec:
         app: atomic-update-agent
     spec:
       serviceAccountName: default
+      # needed for D-Bus over abstract UNIX sockets in host network namespace
+      hostNetwork: true
       containers:
       - name: update-agent
         image: quay.io/spiketesting/atomic-update-operator:v0.0.0


### PR DESCRIPTION
As discussed, let's switch our agent from relying on the shipped rpm-ostree timer and doing the upgrades itself. There are a bunch of obvious issues and enhancements lingering in this code (marked as `XXX` :)), but I've confirmed that it works as intended. It seems "good enough" for POC purposes.