### PR TITLE
README: Rework to match new reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,42 @@
-# Container Linux Update Operator
+# CoreOS v2 Update Operator (rpm-ostree version)
 
-Container Linux Update Operator is a node reboot controller for Kubernetes running
-Container Linux images. When a reboot is needed after updating the system via
-[update_engine](https://github.com/coreos/update_engine), the operator will
-drain the node before rebooting it.
+CoreOS Update Operator is a version of
+the [Container Linux Update Operator](https://github.com/coreos/container-linux-update-operator) adapted
+for [rpm-ostree](https://github.com/projectatomic/rpm-ostree).
 
-Container Linux Update Operator fulfills the same purpose as
-[locksmith](https://github.com/coreos/locksmith), but has better integration
-with Kubernetes by explicitly marking a node as unschedulable and deleting pods
-on the node before rebooting.
+It synchronizes host updates, integrating with Kubernetes, helping
+to ensure seamless upgrades of the base operating system in a cluster.
 
-## Design
-
-[Original proposal](https://docs.google.com/document/d/1DHiB2UDBYRU6QSa2e9mCNla1qBivZDqYjBVn_DvzDWc/edit#)
-
-Container Linux Update Operator is divided into two parts: `update-operator` and `update-agent`.
-
-`update-agent` runs as a DaemonSet on each node, waiting for a `UPDATE_STATUS_UPDATED_NEED_REBOOT` signal via D-Bus from `update_engine`.
-It will indicate via [node annotations](./pkg/constants/constants.go) that it needs a reboot.
-
-`update-operator` runs as a Deployment, watching changes to node annotations and reboots the nodes as needed.
-It coordinates the reboots of multiple nodes in the cluster, ensuring that not too many are rebooting at once.
+There are two parts, an `update-agent` which runs as a DaemonSet on each node,
+and an `update-operator` runs as a Deployment, watching changes to node
+annotations and reboots the nodes as needed. It coordinates the reboots of
+multiple nodes in the cluster, ensuring that not too many are rebooting at once.
 
 Currently, `update-operator` only reboots one node at a time.
 
+This operator fulfills the same purpose
+as [locksmith](https://github.com/coreos/locksmith). And for people familiar
+with `yum` based systems, one could think of `rpm-ostree` as on the same level
+as `yum`, the `update-agent` as similar to `yum-cron` . The operator equivalent
+might be implemented via configuration management or scripting.
+
+The advantage of this operator over both is its integration with Kubernetes.
+
+## More detailed design
+
+[Original proposal](https://docs.google.com/document/d/1DHiB2UDBYRU6QSa2e9mCNla1qBivZDqYjBVn_DvzDWc/edit#)
+
+The CoreOS v2 `update-agent` more directly tells rpm-ostree to upgrade, rather than
+relying on a timer in `rpm-ostree` itself.  Then, if an update is available `rpm-ostree`
+will expose a "cached update" property via DBus.  The agent will then
+indicate via [node annotations](./pkg/constants/constants.go) that it needs a reboot.
+
+The operator watches all node annotations, and takes care of choosing which
+node to drain and reboot.
+
 ## Requirements
 
-- A Kubernetes cluster (>= 1.6) running on Container Linux
-- The `update-engine.service` systemd unit on each machine should be unmasked, enabled and started in systemd
-- The `locksmithd.service` systemd unit on each machine should be masked and stopped in systemd
-
-To unmask a service, run `systemctl unmask <name>`.
-To enable a service, run `systemctl enable <name>`.
-To start/stop a service, run `systemctl start <name>` or `systemctl stop <name>` respectively.
+- A Kubernetes cluster (>= 1.6) running on a system using `rpm-ostree` such as today's Fedora Atomic
 
 ## Usage
 
@@ -44,4 +48,5 @@ kubectl apply -f examples/deploy -R
 
 ## Test
 
-To test that it is working, you can SSH to a node and trigger an update check by running `update_engine_client -check_for_update` or simulate a reboot is needed by running `locksmithctl send-need-reboot`.
+To test that it is working, you could use `rpm-ostree deploy` to reset hosts
+to previous versions, then enable the operator.


### PR DESCRIPTION
There are some notable architectural changes we made; for example,
the agent now directly tells rpm-ostree to upgrade.

Rewriting this was helpful for me to ensure I understand it all,
and hopefully for others!